### PR TITLE
Add support for 16-bit verbnums in I6 library w/ Glulx

### DIFF
--- a/infix.h
+++ b/infix.h
@@ -968,7 +968,7 @@ Array InfixRV_commas --> 32;
         for (b=0 : b < #dictionary_table-->0 : b++) {
             w = #dictionary_table + WORDSIZE + b*(DICT_WORD_SIZE + 7);
             if ((w->#dict_par1) & 1) {
-                a = (#grammar_table)-->($100-(w->#dict_par2));
+                a = (#grammar_table)-->(DictionaryWordToVerbNum(w) + 1);
                 lines = a->0; a++;
                 for (: lines>0 : lines--) {
                     a = UnpackGrammarLine(a);

--- a/parser.h
+++ b/parser.h
@@ -1489,6 +1489,24 @@ Object  InformParser "(Inform Parser)"
     return 1;
 ];
 
+! ==========================
+! Taken from I7's Parser.i6t
+! ==========================
+
+[ DictionaryWordToVerbNum dword verbnum;
+#Ifdef TARGET_ZCODE;
+    verbnum = $ff-(dword->#dict_par2);
+#Ifnot; ! GLULX
+    dword = dword + #dict_par2 - 1;
+    @aloads dword 0 verbnum;
+    verbnum = $ffff-verbnum;
+#Endif;
+    return verbnum;
+];
+
+! ==========================
+
+
 ! ----------------------------------------------------------------------------
 !   To simplify the picture a little, a rough map of the main routine:
 !
@@ -1857,7 +1875,7 @@ Object  InformParser "(Inform Parser)"
     ! Now let i be the corresponding verb number, stored in the dictionary entry
     ! (in a peculiar 255-n fashion for traditional Infocom reasons)...
 
-    i = $ff-(verb_word->#dict_par2);
+    i = DictionaryWordToVerbNum(verb_word);
 
     ! ...then look up the i-th entry in the verb table, whose address is at word
     ! 7 in the Z-machine (in the header), so as to get the address of the syntax
@@ -5932,7 +5950,7 @@ Object  InformLibrary "(Inform Library)"
 
 #Ifnot; ! TARGET_GLULX
 
-[ ShowVerbSub grammar lines j wd dictlen entrylen;
+[ ShowVerbSub grammar lines i j wd dictlen entrylen;
     if (noun == 0 || ((noun->#dict_par1) & DICT_VERB) == 0)
         "Try typing ~showverb~ and then the name of a verb.";
     print "Verb";
@@ -5945,7 +5963,8 @@ Object  InformLibrary "(Inform Library)"
             print " '", (address) wd, "'";
     }
     new_line;
-    grammar = (#grammar_table)-->($ff-(noun->#dict_par2)+1);
+    i = DictionaryWordToVerbNum(noun);
+    grammar = (#grammar_table)-->(i+1);
     lines = grammar->0;
     grammar++;
     if (lines == 0) "has no grammar lines.";


### PR DESCRIPTION
Compiler 6.32 added support for 16-bit verbnums when using Glulx, but the library never took advantage of them. I've backported a few changes from I7 to support this, and they seem to work, though more knowledgeable eyes may want to look the changes over.

Edit: after looking through the compiler sources in verbs.c and text.c, I'm more confident that these patches should be okay.